### PR TITLE
Fix relative paths in scripts

### DIFF
--- a/scripts/finetuning.py
+++ b/scripts/finetuning.py
@@ -1,10 +1,16 @@
 from openai import OpenAI
 import os
+from pathlib import Path
+
 client = OpenAI(
     api_key=os.environ.get("CUSTOM_ENV_NAME")
 )
+
+# ID of the uploaded training file. The upload step returns this ID.
+training_file_id = ''  # TODO: replace with your uploaded file ID
+
 file_tuning_job = client.fine_tuning.jobs.create(
-    training_file='',
-    model="gpt-3.5-turbo"
+    training_file=training_file_id,
+    model="gpt-3.5-turbo",
 )
 print(file_tuning_job)

--- a/scripts/preprocess_data.py
+++ b/scripts/preprocess_data.py
@@ -1,8 +1,15 @@
 import json
 import random
+from pathlib import Path
+
+# Base directory of this script file so we can build absolute paths. This
+# allows the script to run correctly even when executed from other
+# directories.
+BASE_DIR = Path(__file__).resolve().parent
 
 raw_data = []
-with open('../data/raw/test_datasets.jsonl', 'r', encoding="utf-8") as file:
+raw_data_path = BASE_DIR.parent / 'data' / 'raw' / 'test_datasets.jsonl'
+with open(raw_data_path, 'r', encoding="utf-8") as file:
     for line in file:
         item = json.loads(line)
         raw_data.append(item)
@@ -11,7 +18,8 @@ with open('../data/raw/test_datasets.jsonl', 'r', encoding="utf-8") as file:
 raw_messages = random.sample(raw_data,100)
 
 # 按OpenAI数据规范，将训练数据按行整理成JSON-L文件
-with open('../data/processed/chat_data.jsonl', 'w', encoding="utf-8") as data_file:
+processed_path = BASE_DIR.parent / 'data' / 'processed' / 'chat_data.jsonl'
+with open(processed_path, 'w', encoding="utf-8") as data_file:
     for item in raw_messages:
         data = {"messages": []}
         data["messages"].append({"role": "system", "content": "你是一个医疗助手"})

--- a/scripts/upload_data.py
+++ b/scripts/upload_data.py
@@ -1,10 +1,17 @@
 from openai import OpenAI
 import os
+from pathlib import Path
+
 client = OpenAI(
     api_key=os.environ.get("CUSTOM_ENV_NAME")
 )
+
+# Path to the processed training data relative to this file so the script
+# can be executed from any directory.
+processed_path = Path(__file__).resolve().parent.parent / 'data' / 'processed' / 'chat_data.jsonl'
+
 client_file = client.files.create(
-    file=open("../data/processed/chat_data.jsonl", "rb"),
-    purpose="fine-tune"
+    file=open(processed_path, 'rb'),
+    purpose="fine-tune",
 )
 print(client_file)


### PR DESCRIPTION
## Summary
- make preprocess_data use absolute paths relative to script
- make upload_data and finetuning use absolute paths relative to scripts

## Testing
- `python3 -m py_compile scripts/preprocess_data.py scripts/upload_data.py scripts/finetuning.py`